### PR TITLE
cli now prints valid JSON (instead of Python dict) when no fields are sp...

### DIFF
--- a/TwitterAPI/cli.py
+++ b/TwitterAPI/cli.py
@@ -34,6 +34,7 @@ __license__ = "MIT"
 
 import argparse
 import codecs
+import json
 from pprint import PrettyPrinter
 import sys
 from .TwitterOAuth import TwitterOAuth
@@ -120,7 +121,7 @@ if __name__ == '__main__':
             if 'message' in item:
                 print('ERROR %s: %s' % (item['code'], item['message']))
             elif not args.fields:
-                pp.pprint(item)
+                print(json.dumps(item, ensure_ascii='False'))  
             else:
                 for name in args.fields:
                     value = _search(name, item)


### PR DESCRIPTION
...ecified.

Currently, when running this:

`python -u -m TwitterAPI.cli -e statuses/sample`

we get output like this:

```
{u'delete': {u'status': {u'id': 473954472960344065,
                         u'id_str': u'473954472960344065',
                         u'user_id': 544701609,
                         u'user_id_str': u'544701609'}}}
```

This does not appear to be valid JSON.

This PR changes the output to, e.g.:

```
{"delete": {"status": {"user_id_str": "2369620414", "user_id": 2369620414, "id": 444959584957263872, "id_str": "444959584957263872"}}}
```
