### PR TITLE
Fixed bug in constants specifically users/profile_banner

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -141,7 +141,7 @@ ENDPOINTS = {
 	'users/contributees':                      ('GET',  'api'),
 	'users/contributors':                      ('GET',  'api'),
 	'users/lookup':                            ('GET',  'api'),
-	'users/profile_banner':                    ('get'   'api'),
+	'users/profile_banner':                    ('GET',  'api'),
 	'users/report_spam':                       ('POST', 'api'),
 	'users/search':                            ('GET',  'api'),
 	'users/show':                              ('GET',  'api'),


### PR DESCRIPTION
This was a simple change but was making the TwitterAPI get_endpoint throw an exception.