### PR TITLE
Fix for potential problem while doing /users/lookup request

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -147,7 +147,7 @@ ENDPOINTS = {
 
     'users/contributees':                      ('GET',  'api'),
     'users/contributors':                      ('GET',  'api'),
-    'users/lookup':                            ('GET',  'api'),
+    'users/lookup':                            ('POST',  'api'),
     'users/profile_banner':                    ('GET'   'api'),
     'users/report_spam':                       ('POST', 'api'),
     'users/search':                            ('GET',  'api'),


### PR DESCRIPTION
As [API docs](https://dev.twitter.com/rest/reference/get/users/lookup) suggest, "You are strongly encouraged to use a POST for larger requests", so since lookup is already batch request, it probably makes sense to make it default.