### PR TITLE
Allow argument pass-through for TwitterResponse.json()

### DIFF
--- a/TwitterAPI/TwitterAPI.py
+++ b/TwitterAPI/TwitterAPI.py
@@ -162,9 +162,9 @@ class TwitterResponse(object):
         """:returns: Raw API response text."""
         return self.response.text
 
-    def json(self):
+    def json(self, *args, **kwargs):
         """:returns: response as JSON object."""
-        return self.response.json()
+        return self.response.json(*args, **kwargs)
 
     def get_iterator(self):
         """Get API dependent iterator.

--- a/TwitterAPI/TwitterAPI.py
+++ b/TwitterAPI/TwitterAPI.py
@@ -162,9 +162,9 @@ class TwitterResponse(object):
         """:returns: Raw API response text."""
         return self.response.text
 
-    def json(self, *args, **kwargs):
+    def json(self, **kwargs):
         """:returns: response as JSON object."""
-        return self.response.json(*args, **kwargs)
+        return self.response.json(**kwargs)
 
     def get_iterator(self):
         """Get API dependent iterator.


### PR DESCRIPTION
Would be nice, haven't tested though but I don't see what could go wrong.