### PR TITLE
Add timeout to api.request

### DIFF
--- a/TwitterAPI/TwitterAPI.py
+++ b/TwitterAPI/TwitterAPI.py
@@ -83,13 +83,14 @@ class TwitterAPI(object):
         else:
             return (resource, resource)
 
-    def request(self, resource, params=None, files=None, method_override=None):
+    def request(self, resource, params=None, files=None, method_override=None, timeout_override=None):
         """Request a Twitter REST API or Streaming API resource.
 
         :param resource: A valid Twitter endpoint (ex. "search/tweets")
         :param params: Dictionary with endpoint parameters or None (default)
         :param files: Dictionary with multipart-encoded file or None (default)
         :param method_override: Request method to override or None (default)
+        :param timeout_override: Read timeout to override or None (default)
 
         :returns: TwitterResponse
         :raises: TwitterConnectionError
@@ -120,6 +121,8 @@ class TwitterAPI(object):
                 params = None
             else:
                 data = None
+            if timeout_override:
+                timeout = timeout_override
             try:
                 r = session.request(
                     method,

--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -1,9 +1,9 @@
 """
 	Constants For All Twitter Endpoints
 	-----------------------------------
-	
+
 	Version 1.1, Streaming API and REST API.
-	
+
 	URLs for each endpoint are composed of the following pieces:
 		PROTOCOL://{subdomain}.DOMAIN/VERSION/{resource}?{parameters}
 """
@@ -23,7 +23,7 @@ CURATOR_VERSION = 'broadcast/1'
 
 USER_AGENT = 'python-TwitterAPI'
 
-CONNECTION_TIMEOUT = 5
+CONNECTION_TIMEOUT = 10
 STREAMING_TIMEOUT = 90
 REST_TIMEOUT = 5
 


### PR DESCRIPTION
This fixes #84 by increasing the `CONNECTION_TIMEOUT` constant from `5` to `10`. Furthermore it adds a `timeout_override` parameter to the `request` method. 