### PR TITLE
add Typing indicator endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea/*
+env/*

--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -74,7 +74,8 @@ ENDPOINTS = {
     'direct_messages/welcome_messages/rules/list':          ('GET',    'api'),
     'direct_messages/welcome_messages/rules/show':          ('GET',    'api'),    
     'direct_messages/welcome_messages/rules/destroy':       ('DELETE', 'api'),        
-        
+    'direct_messages/indicate_typing':                      ('POST',   'api'),
+
     'favorites/create':                                     ('POST',   'api'),
     'favorites/destroy':                                    ('POST',   'api'),
     'favorites/list':                                       ('GET',    'api'),


### PR DESCRIPTION
Hello!
I added type indicator Endpoint, it works.
Make a request by this manual
https://developer.twitter.com/en/docs/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
Please merge to publish changes in your lib. Thx.
