### PR TITLE
Feature/pass error msg

### DIFF
--- a/TwitterAPI/TwitterAPI.py
+++ b/TwitterAPI/TwitterAPI.py
@@ -217,7 +217,7 @@ class TwitterResponse(object):
         :raises: TwitterConnectionError, TwitterRequestError
         """
         if self.response.status_code != 200:
-            raise TwitterRequestError(self.response.status_code)
+            raise TwitterRequestError(self.response.status_code, msg=self.response.text)
 
         if self.stream:
             return iter(_StreamingIterable(self.response))

--- a/TwitterAPI/TwitterError.py
+++ b/TwitterAPI/TwitterError.py
@@ -25,14 +25,16 @@ class TwitterRequestError(TwitterError):
 
     """Raised when request fails"""
 
-    def __init__(self, status_code):
-        if status_code >= 500:
-            msg = 'Twitter internal error (you may re-try)'
-        else:
-            msg = 'Twitter request failed'
+    def __init__(self, status_code, msg=None):
+        if msg is None:
+            if status_code >= 500:
+                msg = 'Twitter internal error (you may re-try)'
+            else:
+                msg = 'Twitter request failed'
         logging.info('Status code %d: %s' % (status_code, msg))
         super(Exception, self).__init__(msg)
         self.status_code = status_code
-        
+        self.msg = msg
+
     def __str__(self):
-        return '%s (%d)' % (self.args[0], self.status_code)
+        return '%s (%d): %s' % (self.args[0], self.status_code, self.msg)


### PR DESCRIPTION
Twitter API `422` response usually includes more detailed "what's the problem" and this is not being passed, so an attempt here to just stick it in the `TwitterRequestError`, so upstream may but doesn't have to use it.

**STATUS**: ~Dry-coded, not yet properly tested.~ Tested, works as expected.