### PR TITLE
Make exception raising configurable on TwitterPager

### DIFF
--- a/TwitterAPI/TwitterPager.py
+++ b/TwitterAPI/TwitterPager.py
@@ -20,6 +20,10 @@ class TwitterPager(object):
     :param params: Dictionary of resource parameters
     """
 
+    # static properties to be overridden if desired
+    RAISE_CONNECTION_ERROR = False
+    RAISE_REQUEST_ERROR = False
+
     def __init__(self, api, resource, params=None):
         self.api = api
         self.resource = resource
@@ -106,8 +110,14 @@ class TwitterPager(object):
                     continue
 
             except TwitterRequestError as e:
+                if self.RAISE_REQUEST_ERROR:
+                    raise
+
                 if e.status_code < 500:
                     raise
                 continue
             except TwitterConnectionError:
+                if self.RAISE_CONNECTION_ERROR:
+                    raise
+
                 continue


### PR DESCRIPTION
For Free APIs continuing on all network errors etc. is probably fine, but very much not so on the paid APIs (they do count your request even if you got read timeout... speaking from experience).

Given `TwitterAPI` uses props on class I've decided, for sake of consistency, to use the same mechanism here.

**STATUS: ~UNTESTED~** Couldn't replicate network errors, but rest works and well, if it doesn't I'll _know_ and fix it...