### PR TITLE
Adding support to some /2/users/:id endpoints

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -247,6 +247,7 @@ ENDPOINTS = {
     'users/:PARAM':                                         ('GET',    'api'), # ID
     'users/:PARAM/followers':                               ('GET',    'api'), # ID
     'users/:PARAM/following':                               ('GET',    'api'), # ID
+    'users/:PARAM/tweets':                                  ('GET',    'api'), # ID
     'users/by':                                             ('GET',    'api'),
     'users/by/username/:PARAM':                             ('GET',    'api'), # USERNAME
 }

--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -245,6 +245,8 @@ ENDPOINTS = {
     'tweets/search/stream/rules':                           ('POST',   'api'), # use method_override for 'GET'
     'users':                                                ('GET',    'api'),
     'users/:PARAM':                                         ('GET',    'api'), # ID
+    'users/:PARAM/followers':                               ('GET',    'api'), # ID
+    'users/:PARAM/following':                               ('GET',    'api'), # ID
     'users/by':                                             ('GET',    'api'),
     'users/by/username/:PARAM':                             ('GET',    'api'), # USERNAME
 }

--- a/examples/v2/user_followers_following.py
+++ b/examples/v2/user_followers_following.py
@@ -7,15 +7,12 @@ try:
     api = TwitterAPI(o.consumer_key, o.consumer_secret, o.access_token_key, o.access_token_secret, api_version='2')
     
     # Get followers
-    r = api.request(f'users/:{USER_ID}/followers')
-    followers = r.json()['data']
+    followers = api.request(f'users/:{USER_ID}/followers')
     for f in followers:
         print(f)
     
     # Get following
-    for item in r:
-    r = api.request(f'users/:{USER_ID}/following')
-    following = r.json()['data']
+    following = api.request(f'users/:{USER_ID}/following')
     for f in following:
         print(f)
 

--- a/examples/v2/user_followers_following.py
+++ b/examples/v2/user_followers_following.py
@@ -1,6 +1,6 @@
 from TwitterAPI import TwitterAPI, TwitterOAuth, TwitterRequestError, TwitterConnectionError
 
-USER_ID = 'id'
+USER_ID = '2244994945'  # https://twitter.com/TwitterDev
 
 try:
     o = TwitterOAuth.read_file()

--- a/examples/v2/user_followers_following.py
+++ b/examples/v2/user_followers_following.py
@@ -1,0 +1,31 @@
+from TwitterAPI import TwitterAPI, TwitterOAuth, TwitterRequestError, TwitterConnectionError
+
+USER_ID = 'id'
+
+try:
+    o = TwitterOAuth.read_file()
+    api = TwitterAPI(o.consumer_key, o.consumer_secret, o.access_token_key, o.access_token_secret, api_version='2')
+    
+    # Get followers
+    r = api.request(f'users/:{USER_ID}/followers')
+    followers = r.json()['data']
+    for f in followers:
+        print(f)
+    
+    # Get following
+    for item in r:
+    r = api.request(f'users/:{USER_ID}/following')
+    following = r.json()['data']
+    for f in following:
+        print(f)
+
+except TwitterRequestError as e:
+    print(e.status_code)
+    for msg in iter(e):
+        print(msg)
+
+except TwitterConnectionError as e:
+    print(e)
+
+except Exception as e:
+    print(e)

--- a/examples/v2/user_tweets.py
+++ b/examples/v2/user_tweets.py
@@ -1,0 +1,43 @@
+from TwitterAPI import TwitterAPI, TwitterOAuth, TwitterRequestError, TwitterConnectionError
+from pprint import pprint
+
+USER_ID = '2244994945'  # https://twitter.com/TwitterDev
+
+try:
+    o = TwitterOAuth.read_file()
+    api = TwitterAPI(o.consumer_key, o.consumer_secret, o.access_token_key, o.access_token_secret, api_version='2')
+
+    # Get tweets - default setting
+    tweets = api.request(f'users/:{USER_ID}/tweets')
+    for t in tweets:
+        print(t)
+
+    # Get tweets with customization - (5 tweets only with created_at timestamp)
+    print()
+    params = {'max_results': 5, 'tweet.fields': 'created_at'}
+    tweets = api.request(f'users/:{USER_ID}/tweets', params)
+    for t in tweets:
+        pprint(t)
+        
+    # Get next 5 tweets
+    print()
+    next_token = tweets.json()['meta']['next_token']
+    params = {'max_results': 5, 'tweet.fields': 'created_at', 'pagination_token': next_token}
+    tweets = api.request(f'users/:{USER_ID}/tweets', params)
+    for t in tweets:
+        pprint(t)    
+    
+        
+except TwitterRequestError as e:
+    print('Request error')
+    print(e.status_code)
+    for msg in iter(e):
+        print(msg)
+
+except TwitterConnectionError as e:
+    print('Connection error')
+    print(e)
+
+except Exception as e:
+    print('Exception')
+    print(e)


### PR DESCRIPTION
Adding support to the following v2 endpoints (examples are included):

- GET /2/users/:id/following
- GET /2/users/:id/followers
- GET /2/users/:id/tweets

See [Follows lookup](https://developer.twitter.com/en/docs/twitter-api/users/follows/api-reference) and [Timelines](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets) for reference. Unfortunately, `TwitterPager` doesn't work out of the box to paginate these results.