### PR TITLE
Fix TwitterPager KeyError for tweets endpoint

### DIFF
--- a/TwitterAPI/TwitterPager.py
+++ b/TwitterAPI/TwitterPager.py
@@ -97,6 +97,8 @@ class TwitterPager(object):
                     elif not new_tweets and item_count == 0:
                         break
                 else: # VERSION 2
+                    if 'meta' not in data:
+                        break
                     meta = data['meta']
                     if not new_tweets and not 'next_token' in meta:
                         break


### PR DESCRIPTION
Fix KeyError when using TwitterPager for `tweets` endpoint and any other endpoint that doesn't return a response with `meta` property.

Fixes #194 