### PR TITLE
Update Ads Version - Deadline August 31, 2021

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -20,7 +20,7 @@ DOMAIN = 'twitter.com'
 
 VERSION = '1.1'
 CURATOR_VERSION = 'broadcast/1'
-ADS_VERSION = '8'
+ADS_VERSION = '9'
 
 
 ENDPOINTS = {


### PR DESCRIPTION
Fixes #197 

"Mark your calendars for Tuesday, August 31, 2021, the end of life date for v8 of the Twitter Ads API."

[Changes are outlined here.](https://twittercommunity.com/t/ads-api-version-9/150316?utm_campaign=ADS_PU_GBL_EN_V8_InitialNotice_Sunset%20Notification_210713&utm_medium=email&utm_source=Eloqua&ref=)


**Line Item/Ad Group Detail changes**
I don't see any of these changed fields specifically called out in this repo.

**Line Item/Ad Group Mobile App Promotion changes**
I don't see any of these changed fields specifically called out in this repo.

- [x] Test with promoted_tweets endpoint