### PR TITLE
Add comment about hydrate_type == NONE side effect

### DIFF
--- a/TwitterAPI/TwitterAPI.py
+++ b/TwitterAPI/TwitterAPI.py
@@ -150,7 +150,7 @@ class TwitterAPI(object):
         :param files: Dictionary with multipart-encoded file or None (default)
         :param method_override: Request method to override or None (default)
         :param hydrate_type: HydrateType or int
-                             Do not hydrate - NONE or 0 (default)
+                             Do not hydrate ('includes' field and all its content will be lost for non-streaming requests) - NONE or 0 (default)
                              Append new field with '_hydrate' suffix with hydrate values - APPEND or 1
                              Replace current field value with hydrate values - REPLACE or 2
 


### PR DESCRIPTION
Related issue: #202 

As described in the issue, `hydrate_type=HydrateType.NONE` in the `TwitterAPI.request` method does not return `includes` field at all (it's lost). By design, the `_RestIterable` object yielding a `list` (made of `response['data']`), it's not necessary to try to merge `includes` to `data`, as the hydration feature already does so.

So, this commit just adds a comment about this for documentation sake, and to avoid having to read the code to understand why `includes` vanishes from the responses.

This behavior is true for non-streaming queries only.