### PR TITLE
Adding V2 tweet counts endpoints list.

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -245,6 +245,8 @@ ENDPOINTS = {
     'tweets/:PARAM':                                        ('GET',    'api'), # ID
     'tweets/compliance/jobs':                               ('POST',   'api'), # use method_override for 'GET'
     'tweets/compliance/jobs/:PARAM':                        ('POST',   'api'), # ID
+    'tweets/counts/all':                                    ('GET',    'api'),
+    'tweets/counts/recent':                                 ('GET',    'api'),
     'tweets/sample/stream':                                 ('GET',    'api'),
     'tweets/search/all':                                    ('GET',    'api'),
     'tweets/search/recent':                                 ('GET',    'api'),

--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -254,10 +254,12 @@ ENDPOINTS = {
     'tweets/search/stream/rules':                           ('POST',   'api'), # use method_override for 'GET'
     'users':                                                ('GET',    'api'),
     'users/:PARAM':                                         ('GET',    'api'), # ID
+    'users/:PARAM/blocking':                                ('GET',    'api'), # ID
     'users/:PARAM/followers':                               ('GET',    'api'), # ID
     'users/:PARAM/following':                               ('GET',    'api'), # ID, use method_override for 'POST'
     'users/:PARAM/following/:PARAM':                        ('DELETE', 'api'), # USER SOURCE ID, USER TARGET ID
     'users/:PARAM/mentions':                                ('GET',    'api'), # ID
+    'users/:PARAM/muting':                                  ('GET',    'api'), # ID
     'users/:PARAM/tweets':                                  ('GET',    'api'), # ID
     'users/:PARAM/liked_tweets':                            ('GET',    'api'), # ID
     'users/:PARAM/likes':                                   ('POST',   'api'), # ID


### PR DESCRIPTION
Adding support for the [V2 Tweet count endpoint](https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-recent).