### PR TITLE
Upgrade Ads API to version 10

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -20,7 +20,7 @@ DOMAIN = 'twitter.com'
 
 VERSION = '1.1'
 CURATOR_VERSION = 'broadcast/1'
-ADS_VERSION = '9'
+ADS_VERSION = '10'
 
 
 ENDPOINTS = {


### PR DESCRIPTION
Upgrade Ads API to version 10 - Deadline is March 31, 2022.

Fixes #211 

Changelog can be found [here](https://twittercommunity.com/t/ads-api-version-10/158787).