### PR TITLE
Update twitter ads api to v11

### DIFF
--- a/TwitterAPI/constants.py
+++ b/TwitterAPI/constants.py
@@ -20,7 +20,7 @@ DOMAIN = 'twitter.com'
 
 VERSION = '1.1'
 CURATOR_VERSION = 'broadcast/1'
-ADS_VERSION = '10'
+ADS_VERSION = '11'
 
 
 ENDPOINTS = {


### PR DESCRIPTION
Update Twitter Ads API to v11 - End of life for v10 October 27, 2022

Fixes #218 

More info can be found [here](https://twittercommunity.com/t/ads-api-version-11/168814)