### PR TITLE
fix(TwitterAPI): Use the json attribute to attach metadata

### DIFF
--- a/TwitterAPI/TwitterAPI.py
+++ b/TwitterAPI/TwitterAPI.py
@@ -201,7 +201,7 @@ class TwitterAPI(object):
                 timeout = self.REST_TIMEOUT
             d = p = j = None
             if method == 'POST':
-                if self.version == '1.1':
+                if self.version == '1.1' and 'metadata' not in resource:
                     d = params
                 else:
                     j = params


### PR DESCRIPTION
This PR tweaks the [request](https://github.com/geduldig/TwitterAPI/blob/5c07c02fce51302e747190a47b6c6796fee23352/TwitterAPI/TwitterAPI.py#L155) method to use the json attribute instead of the data attribute to attach additional metadata using the media/metadata/create endpoint from the v1.1 API. 

This PR fixes https://github.com/geduldig/TwitterAPI/issues/224